### PR TITLE
version control miniforge3 but do not activate a base env

### DIFF
--- a/docker_recipes/bbmap_v_39.08.Dockerfile
+++ b/docker_recipes/bbmap_v_39.08.Dockerfile
@@ -12,5 +12,11 @@ RUN cd /opt/ && \
     tar -zxvf download && \
     rm -rf download # clean up to reduce container size
 
+# install conda due to dependancy bug in snakemake but will not be used for installing software
+RUN cd /opt/ && \
+    wget https://github.com/conda-forge/miniforge/releases/download/24.11.3-2/Miniforge3-24.11.3-2-Linux-x86_64.sh && \
+    chmod a+x Miniforge3-24.11.3-2-Linux-x86_64.sh && \
+    bash Miniforge3-24.11.3-2-Linux-x86_64.sh -b # install in batch mode so not prompted for user input
+
 # add scripts in bbmap to path
-ENV PATH "$PATH:/opt/bbmap/"
+ENV PATH="$PATH:/opt/bbmap/:/root/miniforge3/bin"

--- a/docker_recipes/bowtie1_v_1.3.1.Dockerfile
+++ b/docker_recipes/bowtie1_v_1.3.1.Dockerfile
@@ -16,4 +16,10 @@ RUN cd /opt && \
     rm -rf download # to save image space since already decompressed
 
 # add binary location to path
-ENV PATH "$PATH:/opt/bowtie-1.3.1-linux-x86_64/"
+# install conda due to dependancy bug in snakemake but will not be used for installing software
+RUN cd /opt/ && \
+    wget https://github.com/conda-forge/miniforge/releases/download/24.11.3-2/Miniforge3-24.11.3-2-Linux-x86_64.sh && \
+    chmod a+x Miniforge3-24.11.3-2-Linux-x86_64.sh && \
+    bash Miniforge3-24.11.3-2-Linux-x86_64.sh -b # install in batch mode so not prompted for user input
+
+ENV PATH="$PATH:/opt/bowtie-1.3.1-linux-x86_64/:/root/miniforge3/bin"

--- a/docker_recipes/cutadapt_v_4.2.Dockerfile
+++ b/docker_recipes/cutadapt_v_4.2.Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:24.04
 
 # initial OS library and certificate updates
 RUN apt-get update && \
-    apt-get install -y software-properties-common
+    apt-get install -y software-properties-common wget
 
 # add python repo
 RUN add-apt-repository ppa:deadsnakes/ppa
@@ -18,3 +18,12 @@ RUN apt-get update &&  \
 # this docker container is multiqc, ok with doing it just to install
 # package globally and bypass a virutal env
 RUN pip3 install --no-cache-dir --break-system-packages cutadapt==4.2
+
+# install conda due to dependancy bug in snakemake but will not be used for installing software
+RUN cd /opt/ && \
+    wget https://github.com/conda-forge/miniforge/releases/download/24.11.3-2/Miniforge3-24.11.3-2-Linux-x86_64.sh && \
+    chmod a+x Miniforge3-24.11.3-2-Linux-x86_64.sh && \
+    bash Miniforge3-24.11.3-2-Linux-x86_64.sh -b # install in batch mode so not prompted for user input
+
+# add fastqc executable to path
+ENV PATH="$PATH:/root/miniforge3/bin"

--- a/docker_recipes/fastqc_v_0.12.1.Dockerfile
+++ b/docker_recipes/fastqc_v_0.12.1.Dockerfile
@@ -6,8 +6,17 @@ RUN apt-get update &&  \
     apt-get install -y unzip wget perl default-jre default-jdk && \
     rm -rf /var/lib/apt/lists/*  # Clean up to reduce image size
 
+# install conda due to dependancy bug in snakemake but will not be used for installing software
+RUN cd /opt/ && \
+    wget https://github.com/conda-forge/miniforge/releases/download/24.11.3-2/Miniforge3-24.11.3-2-Linux-x86_64.sh && \
+    chmod a+x Miniforge3-24.11.3-2-Linux-x86_64.sh && \
+    bash Miniforge3-24.11.3-2-Linux-x86_64.sh -b # install in batch mode so not prompted for user input
+
 # download and unzip precompiled binary
-RUN cd /opt/ && wget https://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v0.12.1.zip && unzip fastqc_v0.12.1.zip
+RUN cd /opt/ && \
+    wget https://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v0.12.1.zip && \
+    unzip fastqc_v0.12.1.zip && \
+    rm -rf fastqc_v0.12.1.zip
 
 # add fastqc executable to path
-ENV PATH "$PATH:/opt/FastQC/"
+ENV PATH="$PATH:/opt/FastQC/:/root/miniforge3/bin"

--- a/docker_recipes/multiqc_v_1.26.Dockerfile
+++ b/docker_recipes/multiqc_v_1.26.Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:24.04
 
 # initial OS library and certificate updates
 RUN apt-get update && \
-    apt-get install -y software-properties-common
+    apt-get install -y software-properties-common wget
 
 # add python repo
 RUN add-apt-repository ppa:deadsnakes/ppa
@@ -18,3 +18,12 @@ RUN apt-get update &&  \
 # this docker container is multiqc, ok with doing it just to install
 # package globally and bypass a virutal env
 RUN pip3 install --no-cache-dir --break-system-packages multiqc==1.26
+
+# install conda due to dependancy bug in snakemake but will not be used for installing software
+RUN cd /opt/ && \
+    wget https://github.com/conda-forge/miniforge/releases/download/24.11.3-2/Miniforge3-24.11.3-2-Linux-x86_64.sh && \
+    chmod a+x Miniforge3-24.11.3-2-Linux-x86_64.sh && \
+    bash Miniforge3-24.11.3-2-Linux-x86_64.sh -b # install in batch mode so not prompted for user input
+
+# add fastqc executable to path
+ENV PATH="$PATH:/root/miniforge3/bin"


### PR DESCRIPTION
Updating docker files to have a global conda env that is version controlled but not activated for base env for the purpose of snakemake software that requires the existence of conda despite never being used.  Although conda is installed, all software is installed from source, not conda